### PR TITLE
Add author section to posts

### DIFF
--- a/assets/css/author.css
+++ b/assets/css/author.css
@@ -1,0 +1,13 @@
+.post__author {
+    padding: 1rem;
+    min-height: 10rem;
+}
+
+.author__name a {
+    font-size: 2.4rem;
+}
+
+.author__about {
+    font-size: 1.5rem;
+    margin-inline: 0.5rem;
+}

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -6,7 +6,7 @@ profilePicture = "images/global/iedc_logo.png"
 keywords = ""
 favicon = "favicons/"
 # example ["css/custom.css"]
-customCss = ["css/sidebar.css", "css/applause-button.css"]
+customCss = ["css/sidebar.css", "css/applause-button.css", "css/author.css"]
 # example ["js/custom.js"]
 customJs = []
 mainSections = ['post']

--- a/content/post/indiafoss.md
+++ b/content/post/indiafoss.md
@@ -1,6 +1,14 @@
 ---
 title: "An IndiaFOSS Story"
 date: 2022-08-13T15:23:44+05:30
+authors:
+-
+    name: "Adithya A"
+    website: "https://www.linkedin.com/in/adithyaanilkumar/"
+-
+    name: "Sreehari Sreekumar"
+    website: "https://www.linkedin.com/in/sreehari-sreekumar-596597200/"
+
 Description: ""
 Tags: []
 Categories: []

--- a/themes/anatole/layouts/_default/single.html
+++ b/themes/anatole/layouts/_default/single.html
@@ -67,6 +67,10 @@
 
       {{ .Content }}
 
+      {{- if .Params.authors -}}
+        {{- partial "author.html" . -}}
+      {{- end -}}
+
       {{- if isset .Params "series" -}}
         {{- partial "series.html" . -}}
 

--- a/themes/anatole/layouts/partials/author.html
+++ b/themes/anatole/layouts/partials/author.html
@@ -1,0 +1,29 @@
+<div class="post__author">
+
+    <h2>Written by</h2>
+
+    {{ range .Params.authors }}
+
+    {{ if .name }}
+    <p class="author__name">
+
+        {{ if .website }}
+        <a target="_blank" href={{.website}}>{{ .name }}</a>
+
+        {{ else }}
+        <a>{{ .name }}</a>
+
+        {{ end }}
+
+    </p>
+
+    {{ if .about }}
+    <p class="author__about">{{ .about }}</p>
+    
+    {{ end }}
+
+    {{ end }}
+
+    {{ end }}
+
+</div>


### PR DESCRIPTION
Added author section to posts

Author details can be added to the front matter in the following format
![author_example](https://user-images.githubusercontent.com/93600615/184531614-552657fc-362e-46cf-9e10-c4c24bacfe80.png)

about and website fields are optional